### PR TITLE
Format dates to match slack timestamps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -435,6 +435,11 @@
         "assert-plus": "1.0.0"
       }
     },
+    "date-fns": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
+      "integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw=="
+    },
     "debug": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@octokit/rest": "^15.15.1",
     "csv": "^4.0.0",
+    "date-fns": "^1.29.0",
     "dotenv": "^6.1.0",
     "node-fetch": "^2.2.0",
     "node-zendesk": "^1.3.0",

--- a/src/github/index.js
+++ b/src/github/index.js
@@ -2,6 +2,7 @@ require('dotenv').config()
 
 const getIssues = require('./getIssues.js')
 const generateCSV = require('../utilities/generateCSV.js')
+const formatDateForCSV = require('../utilities/formatDateForCSV.js')
 
 const repositories = [
   'alphagov/govuk-frontend',
@@ -43,7 +44,7 @@ getIssues({
     const headers = [ 'timestamp', 'channel', 'title', 'tag', 'url' ]
     const rows = issues.map(issue => {
       return [
-        issue.created_at,
+        formatDateForCSV(issue.created_at),
         issue.repository_name,
         issue.title,
         issue.strippedLabels.join(','),

--- a/src/github/utilities.js
+++ b/src/github/utilities.js
@@ -1,9 +1,7 @@
+const { format } = require('date-fns')
+
 function formatDateYYYYMMDD (date) {
-  return [
-    date.getFullYear(),
-    ('0' + (date.getMonth() + 1)).slice(-2),
-    ('0' + date.getDate()).slice(-2)
-  ].join('-')
+  return format(date, 'YYYY-MM-DD')
 }
 
 module.exports = {

--- a/src/utilities/formatDateForCSV.js
+++ b/src/utilities/formatDateForCSV.js
@@ -1,0 +1,7 @@
+const { format } = require('date-fns')
+
+function formatDateForCSV (date) {
+  return format(date, 'DD/MM/YYYY HH:MM:SS')
+}
+
+module.exports = formatDateForCSV

--- a/src/zendesk/index.js
+++ b/src/zendesk/index.js
@@ -2,6 +2,7 @@ require('dotenv').config()
 
 const getTicketsWithTags = require('./getTicketsWithTags.js')
 const generateCSV = require('../utilities/generateCSV.js')
+const formatDateForCSV = require('../utilities/formatDateForCSV.js')
 
 console.time('getTicketsWithTags')
 getTicketsWithTags()
@@ -9,7 +10,7 @@ getTicketsWithTags()
     const headers = [ 'timestamp', 'channel', 'title', 'tag', 'url' ]
     const rows = ticketsWithTags.map(ticket => {
       return [
-        ticket.created,
+        formatDateForCSV(ticket.created),
         'Zendesk',
         ticket.subject,
         ticket.strippedTags.join(','),


### PR DESCRIPTION
Allows us to merge the data better.

Also includes date-fns dependency as I'm worried my dodgy date formatting will not be robust enough...