### PR TITLE
Add GitHub Actions workflow to run tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,23 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Run tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          cache: npm
+          node-version: 14
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Ensure any changes to GitHub Actions workflows are reviewed by developers
+.github/workflows/  @alphagov/design-system-developers


### PR DESCRIPTION
It would be good to have tests run before merge, to make sure that we don't break things. This will also run the linter, `standard`. 

I've enabled Actions in the repo settings, once this is merged we can also make the 'Run tests' action a required check for future PRs.